### PR TITLE
add log for day 8 and 9

### DIFF
--- a/prondubuisi_log_day8-9.md
+++ b/prondubuisi_log_day8-9.md
@@ -22,6 +22,19 @@ Looking around the internet for data is helping me learn new things
 | Day 6  | Gather Data  | Empty  | Empty  |
 | Day 7  | Gather Data  | Empty  | Empty  |
 
+ Day Number  |  Planned Work | Delivered| Ticket |
+|---|---|---|---|
+| Day 8  | Gather Data  | Empty  | Empty  |
+| Day 9  | Gather Data  | [poverty and equity data](https://github.com/tapaswenipathak/TheLesserNumber/pull/39)  |  [issue 15](https://github.com/tapaswenipathak/TheLesserNumber/issues/15) |
+
+## Things I completed
+Gathering data on equity an poverty
+## Things that made me stuck
+Gathering data on [gender](https://databank.worldbank.org/data/source/gender-statistics/Type/METADATA/preview/on), as the dataset was to large to export in one swoop, despite many modifications by me
+## Things I liked putting work on
+
+I always learn new things while collecting data, thats a major plus for me
+
 
 
 


### PR DESCRIPTION
In my one month internship I will be submitting per day log.

 Day Number  |  Planned Work | Delivered| Ticket |
|---|---|---|---|
| Day 8  | Gather Data  | Empty  | Empty  |
| Day 9  | Gather Data  | [poverty and equity data](https://github.com/tapaswenipathak/TheLesserNumber/pull/39)  |  [issue 15](https://github.com/tapaswenipathak/TheLesserNumber/issues/15) |

## Things I completed
Gathering data on equity an poverty
## Things that made me stuck
Gathering data on [gender](https://databank.worldbank.org/data/source/gender-statistics/Type/METADATA/preview/on), as the dataset was to large to export in one swoop, despite many modifications by me
## Things I liked putting work on

I always learn new things while collecting data, thats a major plus for me

